### PR TITLE
feat(cli): add --version and -v flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func runCLI(args []string, stdout, stderr io.Writer) int {
 		return runInitCommand(args[1:], os.Stdin, stdout, stderr, stdoutUI)
 	case "status":
 		return runStatusCommand(args[1:], stdout, stderr, stdoutUI)
-	case "version":
+	case "version", "-v", "--version":
 		return runVersionCommand(args[1:], stdout, stderr)
 	default:
 		if strings.HasPrefix(args[0], "-") {


### PR DESCRIPTION
## Summary

Add `--version` and `-v` flags to the CLI

## Why

Standard CLI convention — users expect `relay --version` to work

## Testing

- [x] `go test ./...`
- [ ] `go vet ./...`
- [ ] I updated docs if the user or contributor flow changed

## Review notes

One-line change — reuses existing `runVersionCommand`

## Related

Closes #12 
