### PR TITLE
[codex] add internal/registry dispatch edge tests

### DIFF
--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -56,3 +56,65 @@ func TestRegistry_RegisterListByCategoryCountAndRegisterAll(t *testing.T) {
 	names := []string{resp.Tools[0].Name, resp.Tools[1].Name, resp.Tools[2].Name}
 	assert.ElementsMatch(t, []string{"tool_one", "tool_two", "tool_three"}, names)
 }
+
+func TestRegistry_RegisterAllDispatchesHandler(t *testing.T) {
+	reg := New()
+	reg.Register("workflow", mcp.NewTool("echo"), func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args := req.GetArguments()
+		message, _ := args["message"].(string)
+		return mcp.NewToolResultText("handled:" + message), nil
+	})
+
+	s := server.NewMCPServer("test", "dev", server.WithToolCapabilities(true))
+	reg.RegisterAll(s)
+
+	c, err := client.NewInProcessClient(s)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err = c.Initialize(ctx, mcp.InitializeRequest{})
+	require.NoError(t, err)
+
+	resp, err := c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "echo",
+			Arguments: map[string]any{"message": "registry-ok"},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Content, 1)
+
+	text, ok := resp.Content[0].(mcp.TextContent)
+	require.True(t, ok, "expected text content, got %T", resp.Content[0])
+	assert.Equal(t, "handled:registry-ok", text.Text)
+
+	_, err = c.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: "missing"},
+	})
+	require.Error(t, err)
+}
+
+func TestRegistry_RegisterDuplicateNamesAndNilHandlers(t *testing.T) {
+	reg := New()
+	handler := func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("ok"), nil
+	}
+
+	reg.Register("workflow", mcp.NewTool("duplicate"), handler)
+	reg.Register("workflow", mcp.NewTool("duplicate"), nil)
+
+	tools := reg.List()
+	require.Len(t, tools, 2)
+	assert.Equal(t, "duplicate", tools[0].Definition.Name)
+	assert.Equal(t, "duplicate", tools[1].Definition.Name)
+	assert.NotNil(t, tools[0].Handler)
+	assert.Nil(t, tools[1].Handler)
+
+	workflowTools := reg.ListByCategory("workflow")
+	require.Len(t, workflowTools, 2)
+	assert.NotNil(t, workflowTools[0].Handler)
+	assert.Nil(t, workflowTools[1].Handler)
+}


### PR DESCRIPTION
## What changed

Adds focused `internal/registry` tests for `RegisterAll` dispatch through an in-process MCP client, missing tool calls, duplicate tool names, and nil handlers.

## Why

Closes #28. The registry is the handoff point between tool registration and MCP server dispatch, so these tests lock in current behavior without changing runtime code.

## How you tested

- `gofmt -w .`
- `go test ./internal/registry`
- `go test ./...` (plain local macOS run hit the existing `/var` vs `/private/var` temp-path assertions in `tools`; `internal/registry` passed)
- `TMPDIR="/private${TMPDIR}" go test ./...`
- `go vet ./...`
- `go build ./...`
- `TMPDIR="/private${TMPDIR}" bash scripts/pre-push.sh`

AI assistance: This PR was prepared with OpenAI Codex.

## Checklist

- [x] `gofmt -w .` is clean
- [x] `go vet ./...` is clean
- [x] `go test ./...` passes with normalized `TMPDIR` on macOS; see testing note above
- [x] `go build ./...` succeeds (for release changes)
- [x] README/ADDING_A_TOOL docs updated if user-facing (not user-facing)
- [x] PR is small and focused (one change)
- [x] Issue is linked with `Closes #28` if it exists
